### PR TITLE
fix: enable global theme switching using context API

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import "./styles/App.css";
-import React from "react";
+import React, { useContext } from "react";
 import Home from "./screens/Home";
 import Navbar from "./components/Navbar/Navbar";
 import AddProduct from "./screens/AddProduct";
@@ -7,12 +7,14 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Login from "./screens/Login";
 import Register from "./screens/Register";
 import PrivateRoute from "./components/PrivateRoute";
-
+import { Context as AppContext } from "./contexts/AppContext";
 
 function App() {
+  const { theme } = useContext(AppContext); 
+
   return (
     <BrowserRouter>
-      <div className={`App arian-theme light-theme`}>
+      <div className={`App arian-theme ${theme}`}>
         <Navbar />
         <Routes>
           <Route path="/" element={<Home />} />

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -1,5 +1,5 @@
-import React, { useContext, useEffect, useState } from "react";
-import { Link, useNavigate } from 'react-router-dom';
+import React, { useContext, useEffect } from "react";
+import { useNavigate } from 'react-router-dom';
 import BrandLogo from "./BrandLogo";
 import ThemeToggle from "./ThemeToggle";
 import NavLinks from "./NavLinks";
@@ -8,26 +8,14 @@ import SearchBar from "./SearchBar";
 import { Context as AppContext } from "../../contexts/AppContext";
 
 const Navbar = ({ onSelectCategory, onSearch }) => {
-  const getInitialTheme = () => {
-    const storedTheme = localStorage.getItem("theme");
-    return storedTheme ? storedTheme : "light-theme";
-  };
-
-  const [theme, setTheme] = useState(getInitialTheme());
-  const { token, setToken } = useContext(AppContext);
-  const navigate = useNavigate(); 
+  const { token, setToken, theme } = useContext(AppContext);
+  const navigate = useNavigate();
 
   const isLoggedIn = !!token;
 
-  const toggleTheme = () => {
-    const newTheme = theme === "dark-theme" ? "light-theme" : "dark-theme";
-    setTheme(newTheme);
-    localStorage.setItem("theme", newTheme);
-  };
-
   const handleLogout = () => {
     localStorage.removeItem("token");
-    setToken(null); // Clear context token
+    setToken(null);
     navigate("/login");
   };
 
@@ -36,40 +24,36 @@ const Navbar = ({ onSelectCategory, onSearch }) => {
   }, [theme]);
 
   return (
-    <>
-      <header>
-        <nav className="navbar navbar-expand-lg fixed-top">
-          <div className="container-fluid">
-            <BrandLogo />
+    <header>
+      <nav className="navbar navbar-expand-lg fixed-top">
+        <div className="container-fluid">
+          <BrandLogo />
 
-            <button
-              className="navbar-toggler"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#navbarSupportedContent"
-              aria-controls="navbarSupportedContent"
-              aria-expanded="false"
-              aria-label="Toggle navigation"
-            >
-              <span className="navbar-toggler-icon"></span>
-            </button>
+          <button
+            className="navbar-toggler"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#navbarSupportedContent"
+            aria-controls="navbarSupportedContent"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
+          >
+            <span className="navbar-toggler-icon"></span>
+          </button>
 
-            <div className="collapse navbar-collapse" id="navbarSupportedContent">
-              <NavLinks isLoggedIn={isLoggedIn} onLogout={handleLogout} />
-
-              <ThemeToggle theme={theme} toggleTheme={toggleTheme} />
-
-              <div className="d-flex align-items-center cart">
-                <i className="bi bi-cart me-2" style={{ display: "flex", alignItems: "center" }}>
-                  Cart
-                </i>
-                <SearchBar />
-              </div>
+          <div className="collapse navbar-collapse" id="navbarSupportedContent">
+            <NavLinks isLoggedIn={isLoggedIn} onLogout={handleLogout} />
+            <ThemeToggle />
+            <div className="d-flex align-items-center cart">
+              <i className="bi bi-cart me-2" style={{ display: "flex", alignItems: "center" }}>
+                Cart
+              </i>
+              <SearchBar />
             </div>
           </div>
-        </nav>
-      </header>
-    </>
+        </div>
+      </nav>
+    </header>
   );
 };
 

--- a/src/components/Navbar/ThemeToggle.jsx
+++ b/src/components/Navbar/ThemeToggle.jsx
@@ -1,6 +1,10 @@
-import React from 'react'
+// src/components/Navbar/ThemeToggle.jsx
+import React, { useContext } from "react";
+import { Context as AppContext } from "../../contexts/AppContext";
 
-const ThemeToggle = ({ theme, toggleTheme }) => {
+function ThemeToggle() {
+  const { theme, toggleTheme } = useContext(AppContext);
+
   return (
     <button className="theme-btn" onClick={toggleTheme}>
       {theme === "dark-theme" ? (
@@ -10,6 +14,6 @@ const ThemeToggle = ({ theme, toggleTheme }) => {
       )}
     </button>
   );
-};
+}
 
-export default ThemeToggle
+export default ThemeToggle;

--- a/src/contexts/AppContext.jsx
+++ b/src/contexts/AppContext.jsx
@@ -1,17 +1,34 @@
-import { createContext, useState, useEffect } from "react";
+// src/context/AppContext.jsx
+import React, { createContext, useEffect, useState } from "react";
 
 export const Context = createContext();
 
 export const AppProvider = ({ children }) => {
   const [token, setToken] = useState(null);
 
+  // ✅ Theme state
+  const getInitialTheme = () => localStorage.getItem("theme") || "light-theme";
+  const [theme, setTheme] = useState(getInitialTheme());
+
+  const toggleTheme = () => {
+    const newTheme = theme === "dark-theme" ? "light-theme" : "dark-theme";
+    setTheme(newTheme);
+    localStorage.setItem("theme", newTheme);
+  };
+
+  useEffect(() => {
+    document.body.className = theme;
+  }, [theme]);
+
   useEffect(() => {
     const storedToken = localStorage.getItem("token");
-    if (storedToken) setToken(storedToken);
+    if (storedToken) {
+      setToken(storedToken);
+    }
   }, []);
 
   return (
-    <Context.Provider value={{ token, setToken }}>
+    <Context.Provider value={{ token, setToken, theme, toggleTheme }}>
       {children}
     </Context.Provider>
   );


### PR DESCRIPTION
fix: enable global theme switching using context API

- Moved `useContext(AppContext)` inside App function body to avoid invalid hook call
- Ensured `theme` is applied from context correctly to `<div className="App">`
- Confirmed global theme toggle now works consistently across the app
